### PR TITLE
avro version revert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
       See also: the surefire plugin section and the profiles section.-->
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
-    <avro.version>1.11.3</avro.version>
+    <avro.version>1.9.2</avro.version>
     <parquet.version>1.12.3</parquet.version>
     <helix.version>1.0.4</helix.version>
     <zkclient.version>0.7</zkclient.version>


### PR DESCRIPTION
Reverting the avro version as it causes some incompatibility issue while creating table schema.
This is fixed in latest pinot trunk here.
https://github.com/hypertrace/incubator-pinot/commit/9ead3ff5bc2191e94f94f8847577355904a3709c

We will defer avro version upgrade till next pinot version upgrade or we can also choose to cherry pick the above commit to our version.