### PR TITLE
Upgrade log4j from 2.24.3 to 2.25.3

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -462,11 +462,11 @@ org.apache.kerby:kerby-asn1:2.1.0
 org.apache.kerby:kerby-config:2.1.0
 org.apache.kerby:kerby-pkix:2.1.0
 org.apache.kerby:kerby-util:2.1.0
-org.apache.logging.log4j:log4j-1.2-api:2.24.3
-org.apache.logging.log4j:log4j-api:2.24.3
-org.apache.logging.log4j:log4j-core:2.24.3
-org.apache.logging.log4j:log4j-slf4j-impl:2.24.3
-org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3
+org.apache.logging.log4j:log4j-1.2-api:2.25.3
+org.apache.logging.log4j:log4j-api:2.25.3
+org.apache.logging.log4j:log4j-core:2.25.3
+org.apache.logging.log4j:log4j-slf4j-impl:2.25.3
+org.apache.logging.log4j:log4j-slf4j2-impl:2.25.3
 org.apache.lucene:lucene-analysis-common:9.12.0
 org.apache.lucene:lucene-backward-codecs:9.12.0
 org.apache.lucene:lucene-core:9.12.0

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
     <zstd-jni.version>1.5.7-3</zstd-jni.version>
     <lz4-java.version>1.8.0</lz4-java.version>
     <libthrift.verion>0.18.1</libthrift.verion>
-    <log4j.version>2.24.3</log4j.version>
+    <log4j.version>2.25.3</log4j.version>
     <slf4j.version>2.0.17</slf4j.version>
     <netty.version>4.1.119.Final</netty.version>
     <reactivestreams.version>1.0.4</reactivestreams.version>


### PR DESCRIPTION
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed

Upgrade log4j to fix cve