### PR TITLE
chore: bump deps to fix CVEs (netty, jetty, async-http-client, common…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <zkclient.version>0.11</zkclient.version>
     <jackson.version>2.18.6</jackson.version>
     <zookeeper.version>3.9.5</zookeeper.version>
-    <async-http-client.version>3.0.1</async-http-client.version>
+    <async-http-client.version>3.0.10</async-http-client.version>
     <jersey.version>2.46</jersey.version>
     <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.6.14</swagger.version>
@@ -167,7 +167,7 @@
     <libthrift.verion>0.18.1</libthrift.verion>
     <log4j.version>2.25.4</log4j.version>
     <slf4j.version>2.0.16</slf4j.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.134.Final</netty.version>
     <reactivestreams.version>1.0.4</reactivestreams.version>
     <jts.version>1.20.0</jts.version>
     <h3.version>4.1.1</h3.version>
@@ -201,7 +201,7 @@
     <commons-compress.version>1.27.1</commons-compress.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-csv.version>1.12.0</commons-csv.version>
-    <commons-configuration2.version>2.11.0</commons-configuration2.version>
+    <commons-configuration2.version>2.15.0</commons-configuration2.version>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-io.version>2.18.0</commons-io.version>
     <commons-codec.version>1.17.2</commons-codec.version>
@@ -251,7 +251,7 @@
     <jettison.version>1.5.4</jettison.version>
     <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
     <dnsjava.version>3.6.2</dnsjava.version>
-    <eclipse.jetty.version>9.4.57.v20241219</eclipse.jetty.version>
+    <eclipse.jetty.version>9.4.58.v20250814</eclipse.jetty.version>
     <woodstox.version>7.1.0</woodstox.version>
     <curator.version>5.7.1</curator.version>
     <javassist.version>3.30.2-GA</javassist.version>


### PR DESCRIPTION
## Summary

Bumps four managed dependency versions in the root [pom.xml](cci:7://file:///Users/gautampanchal/Desktop/hypertrace/incubator-pinot/pom.xml:0:0-0:0) to address vulnerabilities reported by the image scan against `hypertrace/pinot:test`. All four are property-only changes; no API breaks are expected (all bumps are within the same minor / `9.4.x` line).

| Property | Before | After | CVEs addressed |
|---|---|---|---|
| `netty.version` | `4.1.132.Final` | `4.1.134.Final` | CVE-2026-42579, -42580, -42581, -42583, -42584, -42585, -42586, -42587, -41417, -44248, -42578 |
| `async-http-client.version` | `3.0.1` | `3.0.10` | CVE-2026-40490 |
| `commons-configuration2.version` | `2.11.0` | `2.15.0` | CVE-2026-45205 |
| `eclipse.jetty.version` | `9.4.57.v20241219` | `9.4.58.v20250814` | latest patch on the `9.4.x` line (matches upstream `apache/pinot`) |

Dependency-tree verified after the bump:
- All `io.netty:*` artifacts resolve to `4.1.134.Final`.
- `org.asynchttpclient:async-http-client` resolves to `3.0.10`.
- `org.apache.commons:commons-configuration2` resolves to `2.15.0`.
- All `org.eclipse.jetty:*` artifacts resolve to `9.4.58.v20250814`.

## Per-dependency changelogs and diffs

### Netty `4.1.132.Final` → `4.1.134.Final`

`4.1.133.Final` is the upstream security release that fixes the CVEs flagged by the scan; `4.1.134.Final` is a follow-up patch (matches `apache/pinot` master).

Fixes from [`4.1.133.Final`](https://github.com/netty/netty/releases/tag/netty-4.1.133.Final):
- **CVE-2026-42587** (high, 7.5) — `HttpContentDecompressor` accepted an unbounded `maxAllocation` (`netty-codec-http`, `netty-codec-http2`).
- **CVE-2026-42583** (high, 7.5) — `Lz4FrameDecoder` allocated a `ByteBuf` of attacker-controlled size (`netty-codec`).
- **CVE-2026-42579** (high, 7.5) — DNS codec did not enforce RFC limits on message size / label length (`netty-codec-dns`).
- **CVE-2026-42584** (high, 7.3) — `HttpClientCodec` could pair inbound responses with the wrong outbound request after pipelining errors (`netty-codec-http`).
- **CVE-2026-42585** (medium, 6.5) — `HttpObjectDecoder` mis-parsed malformed `Transfer-Encoding` headers (request smuggling) (`netty-codec-http`).
- **CVE-2026-42580** (medium, 6.5) — chunk-size parser silently overflowed (`netty-codec-http`).
- **CVE-2026-42586** (medium, 6.8) — `RedisEncoder` mishandled large frames (`netty-codec-redis`).
- **CVE-2026-42581** (medium, 5.8) — `HttpObjectDecoder` stripped a conflicting header instead of rejecting the request (`netty-codec-http`).
- **CVE-2026-41417** (medium, 5.3) — request-line validation bypass on `DefaultHttpRequest` URI mutation (`netty-codec-http`).
- **CVE-2026-44248** (medium, 5.3) — MQTT 5 header `Properties` parsing issue (`netty-codec-mqtt`).
- **CVE-2026-42578** (low, 2.9) — `HttpProxyHandler` constructed HTTP CONNECT requests without sanitizing user input (`netty-handler-proxy`).

[`4.1.134.Final`](https://github.com/netty/netty/releases/tag/netty-4.1.134.Final) — small follow-up patch, no new CVEs. Picked to stay aligned with `apache/pinot` master.

Diff: https://github.com/netty/netty/compare/netty-4.1.132.Final...netty-4.1.134.Final

### async-http-client `3.0.1` → `3.0.10`

Release notes: https://github.com/AsyncHttpClient/async-http-client/releases

- **CVE-2026-40490** (medium, 6.8) — fixed in `3.0.9`. On redirect follow, AHC could leak credentials (`Authorization` / proxy auth headers) to the redirect target when the redirect crossed origins. Picked `3.0.10` to match `apache/pinot` master.
- `3.0.2`…`3.0.10` are otherwise minor bugfix releases (HTTP/2, Netty version alignment, request-builder fixes); no breaking API changes.

Diff: https://github.com/AsyncHttpClient/async-http-client/compare/v3.0.1...v3.0.10

### commons-configuration2 `2.11.0` → `2.15.0`

Release notes: https://commons.apache.org/proper/commons-configuration/changes-report.html

- **CVE-2026-45205** (medium, 5.3) — fixed in `2.15.0`.
- `2.12.0`, `2.13.0`, `2.14.0`, `2.15.0` are backwards-compatible bugfix / dependency-update releases on the `2.x` line. Mostly: updated commons-text / commons-lang3 / commons-beanutils, hardened YAML / properties parsing, removed unused reflection.
- Same version as `apache/pinot` master (`16b85a76422ebfca1a36975550c72139a98add01`).

Diff: https://github.com/apache/commons-configuration/compare/rel/commons-configuration-2.11.0...rel/commons-configuration-2.15.0

### Eclipse Jetty `9.4.57.v20241219` → `9.4.58.v20250814`

Release notes: https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.58.v20250814

The Jetty CVEs in the scan (CVE-2026-2332, CVE-2025-11143, CVE-2024-6763, CVE-2026-5795) are formally fixed only on the `11.x` / `12.x` lines per Eclipse's advisories; the `9.x` line is in security-maintenance mode. `9.4.58.v20250814` is the latest available patch on the `9.4.x` line and is what `apache/pinot` master is currently on (upstream [pom.xml](cci:7://file:///Users/gautampanchal/Desktop/hypertrace/incubator-pinot/pom.xml:0:0-0:0) comment: "Solve conflicts and vulnerabilities"). Migrating Pinot off Jetty 9.x is a much larger change (Jetty 11/12 moved to the `jakarta.*` servlet API) and is out of scope for this PR.

Diff: https://github.com/jetty/jetty.project/compare/jetty-9.4.57.v20241219...jetty-9.4.58.v20250814

## Not addressed in this PR

- **jackson-core `2.15.4` / `2.18.1`** (GHSA-72hv-8253-57qq) — these come from a previously-built `pinot-parquet-1.3.0-shaded.jar` that was bundled in the scanned image. The project already declares `jackson.version=2.18.6` (the fixed version per the advisory). After this branch's dependency-tree verification, `pinot-parquet` resolves `jackson-core` to `2.18.6`, so a fresh rebuild of the docker image is sufficient to drop these findings. No pom change needed.

## Test plan

- `mvn dependency:tree` on [pinot-core](cci:9://file:///Users/gautampanchal/Desktop/hypertrace/incubator-pinot/pinot-core:0:0-0:0), [pinot-controller](cci:9://file:///Users/gautampanchal/Desktop/hypertrace/incubator-pinot/pinot-controller:0:0-0:0), `pinot-clients/pinot-java-client`, and `pinot-plugins/pinot-input-format/pinot-parquet` — all four target dependencies resolve to the bumped versions and no conflicting older versions remain in the tree.
- CI build + image scan.